### PR TITLE
Expand pyrefly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "mypy == 1.13.0",
     "ufmt == 2.8.0",
     "usort == 1.0.8.post1",
-    "pyrefly == 0.8.0",
+    "pyrefly == 0.10.0",
 ]
 lsp = [
     "pygls[ws] ~= 1.3.1",
@@ -142,12 +142,5 @@ project_includes = [
     "src/fixit/util.py",
     "src/fixit/api.py",
     "src/fixit/engine.py",
+    "src/fixit/ftypes.py",
 ]
-search_path = [
-    "src"
-]
-# TODO: Change this to be passed in as an argument.
-site_package_path = [
-    "/Users/maggiemoss/python_projects/scrapers/lib/python3.13/site-packages"
-]
-python_version = "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ project_includes = [
     # Start by adding a single file and we'll expand as we go
     "src/fixit/util.py",
     "src/fixit/api.py",
+    "src/fixit/engine.py",
 ]
 search_path = [
     "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,12 +139,14 @@ warn_unused_ignores = false
 [tool.pyrefly]
 project_includes = [
     # Start by adding a single file and we'll expand as we go
-    "src/fixit/util.py"
+    "src/fixit/util.py",
+    "src/fixit/api.py",
 ]
 search_path = [
     "src"
 ]
+# TODO: Change this to be passed in as an argument.
 site_package_path = [
-    "venv/lib/python3.12/site-packages"
+    "/Users/maggiemoss/python_projects/scrapers/lib/python3.13/site-packages"
 ]
-python_version = "3.12"
+python_version = "3.13"

--- a/src/fixit/api.py
+++ b/src/fixit/api.py
@@ -52,13 +52,13 @@ def print_result(
         path = path.relative_to(Path.cwd())
     except ValueError:
         pass
-
-    if result.violation:
-        rule_name = result.violation.rule_name
-        start_line = result.violation.range.start.line
-        start_col = result.violation.range.start.column
-        message = result.violation.message
-        if result.violation.autofixable:
+    violation = result.violation
+    if violation:
+        rule_name = violation.rule_name
+        start_line = violation.range.start.line
+        start_col = violation.range.start.column
+        message = violation.message
+        if violation.autofixable:
             message += " (has autofix)"
 
         if output_format == OutputFormat.fixit:
@@ -78,12 +78,13 @@ def print_result(
             raise NotImplementedError(f"output-format = {output_format!r}")
         click.secho(line, fg="yellow", err=stderr)
 
-        if show_diff and result.violation.diff:
-            echo_color_precomputed_diff(result.violation.diff)
+        if show_diff and violation.diff:
+            echo_color_precomputed_diff(violation.diff)
         return True
 
     elif result.error:
         # An exception occurred while processing a file
+        # type: ignore  # not-iterable
         error, tb = result.error
         click.secho(f"{path}: EXCEPTION: {error}", fg="red", err=stderr)
         click.echo(tb.strip(), err=stderr)
@@ -172,6 +173,7 @@ def fixit_stdin(
         content: FileContent = sys.stdin.buffer.read()
         config = generate_config(path, options=options)
 
+        # type: ignore  # type-mismatch
         updated = yield from fixit_bytes(
             path, content, config=config, autofix=autofix, metrics_hook=metrics_hook
         )
@@ -207,6 +209,7 @@ def fixit_file(
         content: FileContent = path.read_bytes()
         config = generate_config(path, options=options)
 
+        # type: ignore  # type-mismatch
         updated = yield from fixit_bytes(
             path, content, config=config, autofix=autofix, metrics_hook=metrics_hook
         )
@@ -306,5 +309,6 @@ def fixit_paths(
             options=options,
             metrics_hook=metrics_hook,
         )
+        # type: ignore  # pyrefly type-mismatch
         for _, results in trailrunner.run_iter(expanded_paths, fn):
             yield from results

--- a/src/fixit/engine.py
+++ b/src/fixit/engine.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path
-from typing import Collection, Generator, Iterator, Mapping, Optional, Set
+from typing import Any, Collection, Generator, Iterator, Mapping, Optional, Set
 
 from libcst import CSTNode, CSTTransformer, Module, parse_module
 from libcst.metadata import FullRepoManager, MetadataWrapper, ProviderT
@@ -32,11 +32,11 @@ def diff_violation(path: Path, module: Module, violation: LintViolation) -> str:
     """
     Generate string diff representation of a violation.
     """
-
     orig = module.code
     mod = module.deep_replace(  # type:ignore # LibCST#906
         violation.node, violation.replacement
     )
+    # type: ignore  # type-mismatch
     assert isinstance(mod, Module)
     change = mod.code
 
@@ -106,6 +106,7 @@ class LintRunner:
             self.metrics[f"Count.{rule.name}"] = len(rule._violations)
             self.metrics[f"FixCount.{rule.name}"] = 0
             for violation in rule._violations:
+                # type: ignore  # pyrefly, todo
                 count += 1
 
                 if violation.replacement:
@@ -118,6 +119,7 @@ class LintRunner:
         self.metrics["Count.Total"] = count
 
         if metrics_hook:
+            # type: ignore # pyrefly bug
             metrics_hook(self.metrics)
 
         return count


### PR DESCRIPTION
## Summary

Example diff that expands the number of files that are being type checked by Pyrefly.  It makes some code changes and takes advantage of a new version of Pyrefly that autodetects site packages, etc.

## Test Plan
`hatch run pyrefly_check`